### PR TITLE
Bumped version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ammo.js",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Direct port of the Bullet physics engine to JavaScript using Emscripten",
   "main": "builds/ammo.js",
   "repository": {


### PR DESCRIPTION
I noticed that there were no tags in this repo. This means that anytime someone (me) pulls it from bower they get the latest, unstable commit. Using a tag he can choose to use a specifik version.
Named it 0.0.2 since package.json named the previous 0.0.1.
