### PR TITLE
Added method setMargin to btConvexHullShape and 3 methods to btCompou…

### DIFF
--- a/ammo.idl
+++ b/ammo.idl
@@ -190,48 +190,56 @@ btConvexTriangleMeshShape implements btConvexShape;
 interface btBoxShape {
   void btBoxShape([Ref] btVector3 boxHalfExtents);
   void setMargin(float margin);
+  float getMargin();
 };
 btBoxShape implements btCollisionShape;
 
 interface btCapsuleShape {
   void btCapsuleShape(float radius, float height);
   void setMargin(float margin);
+  float getMargin();
 };
 btCapsuleShape implements btCollisionShape;
 
 interface btCapsuleShapeX {
   void btCapsuleShapeX(float radius, float height);
   void setMargin(float margin);
+  float getMargin();
 };
 btCapsuleShapeX implements btCapsuleShape;
 
 interface btCapsuleShapeZ {
   void btCapsuleShapeZ(float radius, float height);
   void setMargin(float margin);
+  float getMargin();
 };
 btCapsuleShapeZ implements btCapsuleShape;
 
 interface btCylinderShape {
   void btCylinderShape([Ref] btVector3 halfExtents);
   void setMargin(float margin);
+  float getMargin();
 };
 btCylinderShape implements btCollisionShape;
 
 interface btCylinderShapeX {
   void btCylinderShapeX([Ref] btVector3 halfExtents);
   void setMargin(float margin);
+  float getMargin();
 };
 btCylinderShapeX implements btCylinderShape;
 
 interface btCylinderShapeZ {
   void btCylinderShapeZ([Ref] btVector3 halfExtents);
   void setMargin(float margin);
+  float getMargin();
 };
 btCylinderShapeZ implements btCylinderShape;
 
 interface btSphereShape {
   void btSphereShape(float radius);
   void setMargin(float margin);
+  float getMargin();
 };
 btSphereShape implements btCollisionShape;
 
@@ -243,6 +251,8 @@ btConeShape implements btCollisionShape;
 interface btConvexHullShape {
   void btConvexHullShape();
   void addPoint([Const, Ref] btVector3 point, optional boolean recalculateLocalAABB);
+  void setMargin(float margin);
+  float getMargin();
 };
 btConvexHullShape implements btCollisionShape;
 
@@ -259,7 +269,11 @@ btConeShapeZ implements btConeShape;
 interface btCompoundShape {
   void btCompoundShape(optional boolean enableDynamicAabbTree);
   void addChildShape([Const, Ref] btTransform localTransform, btCollisionShape shape);
+  void removeChildShapeByIndex(long childShapeindex);
+  [Const] long getNumChildShapes();
+  btCollisionShape getChildShape(long index);
   void setMargin(float margin);
+  float getMargin();
 };
 btCompoundShape implements btCollisionShape;
 

--- a/tests/compoundShape.js
+++ b/tests/compoundShape.js
@@ -1,0 +1,120 @@
+
+ 
+var compoundShape = new Ammo.btCompoundShape();
+
+
+var transform = new Ammo.btTransform();
+transform.setIdentity();
+
+var vec = new Ammo.btVector3();
+var quat = new Ammo.btQuaternion();
+quat.setValue(0, 0, 0 , 1);
+
+var margin = 0.01;
+var delta = 0.00001;
+
+// Create box shape
+vec.setValue(0.5, 0.75, 1.25);
+var boxShape = new Ammo.btBoxShape(vec);
+boxShape.setMargin(margin);
+assert(Math.abs(boxShape.getMargin() - margin) < delta, "boxShape margin" );
+vec.setValue(0, 0, 0);
+transform.setOrigin(vec);
+transform.setRotation(quat);
+compoundShape.addChildShape(transform, boxShape);
+
+// Create sphere shape
+var sphereRadius = 0.3;
+var sphereShape = new Ammo.btSphereShape(sphereRadius);
+sphereShape.setMargin(margin);
+// Note: the sphere shape is different from the others, it always returns its radius as the margin.
+assert(Math.abs(sphereShape.getMargin() - sphereRadius) < delta, "sphereShape margin must be equal to the radius" );
+vec.setValue(1, 0, 0);
+transform.setOrigin(vec);
+transform.setRotation(quat);
+compoundShape.addChildShape(transform, sphereShape);
+
+// Create cylinder shape
+vec.setValue(0.3, 0.4, 0.3);
+var cylinderShape = new Ammo.btCylinderShape(vec);
+cylinderShape.setMargin(margin);
+assert(Math.abs(cylinderShape.getMargin() - margin) < delta, "cylinderShape margin" );
+vec.setValue(-1, 0, 0);
+transform.setOrigin(vec);
+transform.setRotation(quat);
+compoundShape.addChildShape(transform, cylinderShape);
+
+// Create cone shape
+var coneShape = new Ammo.btConeShape(0.3, 0.5);
+vec.setValue(0, 1, 0);
+transform.setOrigin(vec);
+transform.setRotation(quat);
+compoundShape.addChildShape(transform, coneShape);
+
+// Create capsule shape
+var capsuleShape = new Ammo.btCapsuleShape(0.4, 0.5);
+capsuleShape.setMargin(margin);
+assert(Math.abs(capsuleShape.getMargin() - margin) < delta, "capsuleShape margin" );
+vec.setValue(0, -1, 0);
+transform.setOrigin(vec);
+transform.setRotation(quat);
+compoundShape.addChildShape(transform, capsuleShape);
+
+// Create convex hull shape
+var convexHullShape = new Ammo.btConvexHullShape();
+vec.setValue(1, 1, 1);
+convexHullShape.addPoint(vec);
+vec.setValue(-1, 1, 1);
+convexHullShape.addPoint(vec);
+vec.setValue(1, -1, 1);
+convexHullShape.addPoint(vec);
+vec.setValue(0, 1, -1);
+convexHullShape.addPoint(vec);
+vec.setValue(0, -2, -1);
+convexHullShape.setMargin(margin);
+assert(Math.abs(convexHullShape.getMargin() - margin) < delta, "convexHullShape margin" );
+transform.setOrigin(vec);
+transform.setRotation(quat);
+compoundShape.addChildShape(transform, convexHullShape);
+
+compoundShape.setMargin(margin);
+assert(Math.abs(compoundShape.getMargin() - margin) < delta, "compoundShape margin" );
+
+// Test number of shapes
+assertEq(compoundShape.getNumChildShapes(), 6, "compoundShape.getNumChildShapes() should return 6");
+
+// Create rigid body
+vec.setValue(10, 5, 2);
+transform.setOrigin(vec);
+transform.setRotation(quat);
+var motionState = new Ammo.btDefaultMotionState(transform);
+var mass = 15;
+compoundShape.calculateLocalInertia(mass, vec);
+var rbInfo = new Ammo.btRigidBodyConstructionInfo(mass, motionState, compoundShape, vec);
+var rigidBody = new Ammo.btRigidBody(rbInfo);
+
+// Set new motion state
+vec.setValue(-30, 50, -10);
+transform.setOrigin(vec);
+transform.setRotation(quat);
+var newMotionState = new Ammo.btDefaultMotionState(transform);
+rigidBody.setMotionState(newMotionState);
+
+// Destroy everything
+for (var shapeIndex = compoundShape.getNumChildShapes() - 1; shapeIndex >= 0; shapeIndex--) {
+    var subShape = compoundShape.getChildShape(shapeIndex);
+    compoundShape.removeChildShapeByIndex(shapeIndex);
+    Ammo.destroy(subShape);
+}
+
+Ammo.destroy(rigidBody.getCollisionShape());
+Ammo.destroy(rigidBody.getMotionState());
+Ammo.destroy(motionState);
+Ammo.destroy(rigidBody);
+Ammo.destroy(rbInfo);
+Ammo.destroy(vec);
+Ammo.destroy(quat);
+Ammo.destroy(transform);
+
+console.log('ok.');
+//print('ok.');


### PR DESCRIPTION
…ndShape.

Added the method `setMargin` to `btConvexHullshape`, and three methods needed to destroy the sub-shapes of a `btCompoundShape` without having to remember them externally, since Bullet does not destroy them when you destroy the `btCompoundShape`.

The new methods in `btCompoundShape` are `removeChildShapeByIndex`, `getNumChildShapes` and `getChildShape`

All methods tested, and the tests passed.