### PR TITLE
Added user pointer and index getters/setters to IDL

### DIFF
--- a/ammo.idl
+++ b/ammo.idl
@@ -96,6 +96,10 @@ interface btCollisionObject {
   void setCollisionShape (btCollisionShape collisionShape);
   void setCcdMotionThreshold (float ccdMotionThreshold);
   void setCcdSweptSphereRadius (float radius);
+  long getUserIndex();
+  void setUserIndex(long index);
+  VoidPtr getUserPointer();
+  void setUserPointer(VoidPtr userPointer);
 };
 
 [NoDelete]

--- a/tests/userData.js
+++ b/tests/userData.js
@@ -1,0 +1,45 @@
+
+var transform = new Ammo.btTransform();
+transform.setIdentity();
+
+var vec = new Ammo.btVector3();
+var quat = new Ammo.btQuaternion();
+quat.setValue(0, 0, 0 , 1);
+
+// Create box shape
+vec.setValue(0.5, 0.5, 0.5);
+var boxShape = new Ammo.btBoxShape(vec);
+
+// Create rigid body
+vec.setValue(0, 0, 0);
+transform.setOrigin(vec);
+transform.setRotation(quat);
+var motionState = new Ammo.btDefaultMotionState(transform);
+var mass = 10;
+boxShape.calculateLocalInertia(mass, vec);
+var rbInfo = new Ammo.btRigidBodyConstructionInfo(mass, motionState, boxShape, vec);
+var rigidBody = new Ammo.btRigidBody(rbInfo);
+
+// Note that in bullet, the user pointer and index are in an union.
+
+var theValue = 1234;
+
+rigidBody.setUserPointer(theValue);
+var userPointer1 = rigidBody.getUserPointer();
+assert(userPointer1.ptr == theValue, "User pointer is not the same" );
+
+theValue = 4567;
+
+rigidBody.setUserIndex(theValue);
+var userIndex1 = rigidBody.getUserIndex();
+assert(userIndex1 == theValue, "User index is not the same" );
+
+Ammo.destroy(rigidBody.getCollisionShape());
+Ammo.destroy(motionState);
+Ammo.destroy(rigidBody);
+Ammo.destroy(rbInfo);
+Ammo.destroy(vec);
+Ammo.destroy(quat);
+Ammo.destroy(transform);
+
+print('ok.');


### PR DESCRIPTION
Another little addition to the IDL. These 4 functions are used to get and set the user index or pointer (wathever the user finds more useful) to each bullet object.
The user values are used to store references to visual objects for example. In my case I use them to store objects ids and retrieve them when iterating through contact points, where I have access to the rigid bodies in contact. This way I know which collision event handler to call.

I've made a test under "tests/userData.js" and tested it in the web browser.