### PR TITLE
Fix broken link to getting started page

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -38,7 +38,7 @@ You can also build ammo.js yourself, as follows:
 
    and set it up. See
 
-      https://github.com/kripken/emscripten/wiki/Getting-started
+      http://kripken.github.io/emscripten-site/docs/getting_started/
 
  * Run the build script,
 


### PR DESCRIPTION
It previously pointed to a nonexistent wiki page. Now it points to the getting started page on the project's website.