### PR TITLE
Patched Bullet to include Raycast fix from 2.83 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -170,5 +170,5 @@ following steps:
 Upstream Version
 ================
 
-Bullet 2.82
+Bullet 2.82 patched with [raycast fix from 2.83](https://github.com/bulletphysics/bullet3/commit/7151865c16ba996996206e1fd7869cbb1e7edd8d)
 

--- a/bullet/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
+++ b/bullet/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
@@ -294,10 +294,11 @@ void	btCollisionWorld::rayTestSingleInternal(const btTransform& rayFromTrans,con
 		//btContinuousConvexCollision convexCaster(castShape,convexShape,&simplexSolver,0);
 		bool condition = true;
 		btConvexCast* convexCasterPtr = 0;
-		if (resultCallback.m_flags & btTriangleRaycastCallback::kF_UseSubSimplexConvexCastRaytest)
-			convexCasterPtr = &subSimplexConvexCaster;
-		else
+		//use kF_UseSubSimplexConvexCastRaytest by default
+		if (resultCallback.m_flags & btTriangleRaycastCallback::kF_UseGjkConvexCastRaytest)
 			convexCasterPtr = &gjkConvexCaster;
+		else
+			convexCasterPtr = &subSimplexConvexCaster;
 		
 		btConvexCast& convexCaster = *convexCasterPtr;
 

--- a/bullet/src/BulletCollision/NarrowPhaseCollision/btRaycastCallback.h
+++ b/bullet/src/BulletCollision/NarrowPhaseCollision/btRaycastCallback.h
@@ -35,8 +35,10 @@ public:
       kF_None                 = 0,
       kF_FilterBackfaces      = 1 << 0,
       kF_KeepUnflippedNormal  = 1 << 1,   // Prevents returned face normal getting flipped when a ray hits a back-facing triangle
-	  kF_UseSubSimplexConvexCastRaytest =  1 << 2,   // Uses an approximate but faster ray versus convex intersection algorithm
-      kF_Terminator        = 0xFFFFFFFF
+	  ///SubSimplexConvexCastRaytest is the default, even if kF_None is set.
+      kF_UseSubSimplexConvexCastRaytest = 1 << 2,   // Uses an approximate but faster ray versus convex intersection algorithm
+      kF_UseGjkConvexCastRaytest = 1 << 3,
+	  kF_Terminator        = 0xFFFFFFFF
    };
    unsigned int m_flags;
 


### PR DESCRIPTION
Integrated RayCast fix from https://github.com/bulletphysics/bullet3/commit/7151865c16ba996996206e1fd7869cbb1e7edd8d

This solves an issue where starting a raycast from inside a physics object would result it being the first object hit by the raycast which is undesirable.