### PR TITLE
Add a bunch of btQuaternion methods 

### DIFF
--- a/ammo.idl
+++ b/ammo.idl
@@ -43,6 +43,7 @@ interface btQuaternion {
   void btQuaternion(float x, float y, float z, float w);
   void setValue(float x, float y, float z, float w);
   void setEulerZYX(float z, float y, float x);
+  void setRotation([Ref] btVector3 axis, float angle);
   void normalize();
   float length2();
   float length();

--- a/ammo.idl
+++ b/ammo.idl
@@ -13,6 +13,7 @@ interface btVector3 {
   void setZ(float z);
   void setValue(float x, float y, float z);
   void normalize();
+  [Value] btVector3 rotate([Ref] btVector3 wAxis, float angle); 
   float dot([Ref] btVector3 v);
   [Operator="*=", Ref] btVector3 op_mul(float x);
   [Operator="+=", Ref] btVector3 op_add([Ref] btVector3 v);
@@ -43,6 +44,11 @@ interface btQuaternion {
   void setValue(float x, float y, float z, float w);
   void setEulerZYX(float z, float y, float x);
   void normalize();
+  [Value] btQuaternion inverse();
+  float getAngle();
+  float getAngleShortestPath();
+  float angle([Ref] btQuaternion q);
+  float angleShortestPath([Ref] btQuaternion q);
 };
 btQuaternion implements btQuadWord;
 

--- a/ammo.idl
+++ b/ammo.idl
@@ -44,11 +44,21 @@ interface btQuaternion {
   void setValue(float x, float y, float z, float w);
   void setEulerZYX(float z, float y, float x);
   void normalize();
+  float length2();
+  float length();
+  float dot([Ref] btQuaternion q);
+  [Value] btQuaternion normalized();
+  [Value] btVector3 getAxis();
   [Value] btQuaternion inverse();
   float getAngle();
   float getAngleShortestPath();
   float angle([Ref] btQuaternion q);
   float angleShortestPath([Ref] btQuaternion q);
+  [Operator="+=", Ref] btQuaternion op_add([Ref] btQuaternion q);
+  [Operator="-=", Ref] btQuaternion op_sub([Ref] btQuaternion q);
+  [Operator="*=", Ref] btQuaternion op_mul(float s);
+  [Operator="*=", Ref] btQuaternion op_mulq([Ref] btQuaternion q);
+  [Operator="/=", Ref] btQuaternion op_div(float s);
 };
 btQuaternion implements btQuadWord;
 


### PR DESCRIPTION
This PR adds:

btVector3:
+  [Value] btVector3 rotate([Ref] btVector3 wAxis, float angle);

btQuaternion:
+  [Value] btQuaternion inverse();
+  float getAngle();
+  float getAngleShortestPath();
+  float angle([Ref] btQuaternion q);
+  float angleShortestPath([Ref] btQuaternion q);
+  float length2();
+  float length();
+  float dot();
+  [Operator="+=", Ref] btQuaternion op_add([Ref] btQuaternion q);
+  [Operator="-=", Ref] btQuaternion op_sub([Ref] btQuaternion q);
+  [Operator="*=", Ref] btQuaternion op_mul(float s);
+  [Operator="*=", Ref] btQuaternion op_mulq([Ref] btQuaternion q);
+  [Operator="/=", Ref] btQuaternion op_div(float s);
+  void setRotation([Ref] btVector3 axis, float angle);

I followed the method listed [https://github.com/kripken/ammo.js/issues/60](here), hope it's OK.

Something worth mentioning: as `operator*=` has two overloads for `btQuaternion`, I named `op_mulq` the one accepting `const btQuaternion&` as a parameter.