### PR TITLE
add 2 methods to btCollisionObject

### DIFF
--- a/ammo.idl
+++ b/ammo.idl
@@ -13,7 +13,7 @@ interface btVector3 {
   void setZ(float z);
   void setValue(float x, float y, float z);
   void normalize();
-  [Value] btVector3 rotate([Ref] btVector3 wAxis, float angle); 
+  [Value] btVector3 rotate([Ref] btVector3 wAxis, float angle);
   float dot([Ref] btVector3 v);
   [Operator="*=", Ref] btVector3 op_mul(float x);
   [Operator="+=", Ref] btVector3 op_add([Ref] btVector3 v);
@@ -104,14 +104,16 @@ interface btCollisionObject {
   void activate(optional boolean forceActivation);
   boolean isActive();
   boolean isKinematicObject();
+  boolean isStaticObject();
+  boolean isStaticOrKinematicObject();
   void setRestitution(float rest);
   void setFriction(float frict);
   void setRollingFriction(float frict);
   [Ref] btTransform getWorldTransform();
   long getCollisionFlags();
   void setCollisionFlags(long flags);
-  void setWorldTransform ([Const,Ref] btTransform worldTrans);
-  void setCollisionShape (btCollisionShape collisionShape);
+  void setWorldTransform([Const,Ref] btTransform worldTrans);
+  void setCollisionShape(btCollisionShape collisionShape);
   void setCcdMotionThreshold (float ccdMotionThreshold);
   void setCcdSweptSphereRadius (float radius);
   long getUserIndex();


### PR DESCRIPTION
I needed these two methods for a project, so I added them.

```
boolean isStaticObject();
boolean isStaticOrKinematicObject();
```

OT: The Python scripts should either be ported to support Python3 as well (which is probably trivial - just add parentheses to all `print`s) or explicitly require Python2 (e.g. by changing the shebang to `#!/usr/bin/env python2` or with an error message if Python3 is being used).
Since Python3 is now the default on many platforms, I'd recommend the first solution.