### PR TITLE
Add more btSoftBody Node attributes in ammo.idl

### DIFF
--- a/ammo.idl
+++ b/ammo.idl
@@ -805,9 +805,12 @@ interface btSoftBodyWorldInfo {
 [Prefix="btSoftBody::"]
 interface Node {
   [Value] attribute btVector3 m_x;
-  [Value] attribute btVector3 m_n;
-  [Value] attribute btVector3 m_f;
+  [Value] attribute btVector3 m_q;
   [Value] attribute btVector3 m_v;
+  [Value] attribute btVector3 m_f;
+  [Value] attribute btVector3 m_n;
+  [Value] attribute btScalar m_im;
+  [Value] attribute btScalar m_area;
 };
 
 [Prefix="btSoftBody::"]


### PR DESCRIPTION
Described in #194 I'm in dire need of m_q. :)
Reordered the parameters so they match official Bullet documentation.