### PR TITLE
add Pointer_stringify to EXPORTED_RUNTIME_METHODS

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -124,6 +124,18 @@ to be aware of:
     | `==`  | `op_eq`  |
 
 
+Reducing Build Size
+===============
+
+The size of the ammo.js builds can be reduced in several ways:
+
+  * Removing uneeded interfaces from ammo.idl
+  Some good examples of this are `btIDebugDraw` and `DebugDrawer`, which are both only needed if visual debug rendering is desired.
+
+  * Removing methods from the `-s EXPORTED_RUNTIME_METHODS=[]` argument in make.py
+  For example, `Pointer_stringify` is only needed if printable error messages are desired from `DebugDrawer`.
+
+
 Troubleshooting
 ===============
 

--- a/README.markdown
+++ b/README.markdown
@@ -129,11 +129,9 @@ Reducing Build Size
 
 The size of the ammo.js builds can be reduced in several ways:
 
-  * Removing uneeded interfaces from ammo.idl
-  Some good examples of this are `btIDebugDraw` and `DebugDrawer`, which are both only needed if visual debug rendering is desired.
+  * Removing uneeded interfaces from ammo.idl. Some good examples of this are `btIDebugDraw` and `DebugDrawer`, which are both only needed if visual debug rendering is desired.
 
-  * Removing methods from the `-s EXPORTED_RUNTIME_METHODS=[]` argument in make.py
-  For example, `Pointer_stringify` is only needed if printable error messages are desired from `DebugDrawer`.
+  * Removing methods from the `-s EXPORTED_RUNTIME_METHODS=[]` argument in make.py. For example, `Pointer_stringify` is only needed if printable error messages are desired from `DebugDrawer`.
 
 
 Troubleshooting

--- a/make.py
+++ b/make.py
@@ -37,7 +37,7 @@ def build():
   wasm = 'wasm' in sys.argv
   closure = 'closure' in sys.argv
 
-  args = '-O3 --llvm-lto 1 -s NO_EXIT_RUNTIME=1 -s NO_FILESYSTEM=1 -s EXPORTED_RUNTIME_METHODS=[]'
+  args = '-O3 --llvm-lto 1 -s NO_EXIT_RUNTIME=1 -s NO_FILESYSTEM=1 -s EXPORTED_RUNTIME_METHODS=["Pointer_stringify"]'
   if not wasm:
     args += ' -s WASM=0 -s AGGRESSIVE_VARIABLE_ELIMINATION=1 -s ELIMINATE_DUPLICATE_FUNCTIONS=1 -s SINGLE_FILE=1 -s LEGACY_VM_SUPPORT=1'
   else:


### PR DESCRIPTION
need Pointer_stringify to print out DOMStrings from `btIDebugDraw` `reportErrorWarning` and `draw3dText`.