### PR TITLE
add btBroadphaseProxy to ammo.idl

### DIFF
--- a/ammo.idl
+++ b/ammo.idl
@@ -437,6 +437,11 @@ interface btDbvtBroadphase {
   void btDbvtBroadphase();
 };
 
+interface btBroadphaseProxy {
+  attribute long m_collisionFilterGroup;
+  attribute long m_collisionFilterMask;
+};
+
 
 // Dynamics
 
@@ -487,6 +492,7 @@ interface btRigidBody {
   void applyGravity();
   [Const, Ref] btVector3 getGravity();
   void setGravity([Const, Ref] btVector3 acceleration);
+  [Const] btBroadphaseProxy getBroadphaseProxy();
 };
 btRigidBody implements btCollisionObject;
 


### PR DESCRIPTION
Also add getBroadphaseProxy() to btRigidBody. This appears to be the best way to modify collisionFilterGroup and collisionFilterMask on an body without removing/re-adding it to the world.