### PR TITLE
 add btConvexPolyhedron to ammo.idl

### DIFF
--- a/ammo.idl
+++ b/ammo.idl
@@ -309,6 +309,43 @@ interface btConeShape {
 };
 btConeShape implements btCollisionShape;
 
+interface btSphereShape {
+  void btSphereShape(float radius);
+  void setMargin(float margin);
+  float getMargin();
+};
+btSphereShape implements btCollisionShape;
+
+interface btConeShape {
+  void btConeShape(float radius, float height);
+};
+btConeShape implements btCollisionShape;
+
+interface btIntArray {
+  long size();
+  long at(long n);
+};
+
+interface btFace {
+  [Value] attribute btIntArray m_indices;
+  attribute float[] m_plane;
+};
+
+interface btVector3Array {
+  long size();
+  [Const, Ref] btVector3 at(long n);
+};
+
+interface btFaceArray {
+  long size();
+  [Const, Ref] btFace at(long n);
+};
+
+interface btConvexPolyhedron {
+  [Value] attribute btVector3Array m_vertices;
+  [Value] attribute btFaceArray m_faces;
+};
+
 interface btConvexHullShape {
   void btConvexHullShape([Const] optional float[] points, optional long numPoints);
   void addPoint([Const, Ref] btVector3 point, optional boolean recalculateLocalAABB);
@@ -316,6 +353,8 @@ interface btConvexHullShape {
   float getMargin();
   long getNumVertices();
   boolean initializePolyhedralFeatures(long shiftVerticesByMargin);
+  void recalcLocalAabb();
+  [Const] btConvexPolyhedron getConvexPolyhedron();
 };
 btConvexHullShape implements btCollisionShape;
 

--- a/ammo.idl
+++ b/ammo.idl
@@ -309,18 +309,6 @@ interface btConeShape {
 };
 btConeShape implements btCollisionShape;
 
-interface btSphereShape {
-  void btSphereShape(float radius);
-  void setMargin(float margin);
-  float getMargin();
-};
-btSphereShape implements btCollisionShape;
-
-interface btConeShape {
-  void btConeShape(float radius, float height);
-};
-btConeShape implements btCollisionShape;
-
 interface btIntArray {
   long size();
   long at(long n);

--- a/idl_templates.h
+++ b/idl_templates.h
@@ -1,0 +1,5 @@
+//Web IDL doesn't seem to support C++ templates so this is the best we can do
+//https://stackoverflow.com/questions/42517010/is-there-a-way-to-create-webidl-bindings-for-c-templated-types#comment82966925_42517010
+typedef btAlignedObjectArray<btVector3> btVector3Array;
+typedef btAlignedObjectArray<btFace> btFaceArray;
+typedef btAlignedObjectArray<int> btIntArray;

--- a/make.py
+++ b/make.py
@@ -5,7 +5,20 @@ from subprocess import Popen, PIPE, STDOUT
 
 # Definitions
 
-INCLUDES = ['btBulletDynamicsCommon.h', os.path.join('BulletCollision', 'CollisionShapes', 'btHeightfieldTerrainShape.h'), os.path.join('BulletCollision', 'CollisionDispatch', 'btGhostObject.h'), os.path.join('BulletDynamics', 'Character', 'btKinematicCharacterController.h'), os.path.join('BulletSoftBody', 'btSoftBody.h'), os.path.join('BulletSoftBody', 'btSoftRigidDynamicsWorld.h'), os.path.join('BulletSoftBody', 'btDefaultSoftBodySolver.h'), os.path.join('BulletSoftBody', 'btSoftBodyRigidBodyCollisionConfiguration.h'), os.path.join('BulletSoftBody', 'btSoftBodyHelpers.h'), os.path.join('BulletCollision', 'CollisionShapes', 'btShapeHull.h')]
+INCLUDES = ['btBulletDynamicsCommon.h',
+os.path.join('BulletCollision', 'CollisionShapes', 'btHeightfieldTerrainShape.h'),
+os.path.join('BulletCollision', 'CollisionShapes', 'btConvexPolyhedron.h'),
+os.path.join('BulletCollision', 'CollisionShapes', 'btShapeHull.h'),
+os.path.join('BulletCollision', 'CollisionDispatch', 'btGhostObject.h'),
+
+os.path.join('BulletDynamics', 'Character', 'btKinematicCharacterController.h'),
+
+os.path.join('BulletSoftBody', 'btSoftBody.h'),
+os.path.join('BulletSoftBody', 'btSoftRigidDynamicsWorld.h'), os.path.join('BulletSoftBody', 'btDefaultSoftBodySolver.h'),
+os.path.join('BulletSoftBody', 'btSoftBodyRigidBodyCollisionConfiguration.h'),
+os.path.join('BulletSoftBody', 'btSoftBodyHelpers.h'),
+
+os.path.join('..', '..', 'idl_templates.h')]
 
 # Startup
 


### PR DESCRIPTION
This gives you easy access to the vertices/faces/normals that btConvexHull computes for you, so you can properly render convex hulls.