### PR TITLE
Expose btStridingMeshInterface.setScaling in IDL

### DIFF
--- a/ammo.idl
+++ b/ammo.idl
@@ -375,6 +375,7 @@ interface btCompoundShape {
 btCompoundShape implements btCollisionShape;
 
 interface btStridingMeshInterface {
+  void setScaling([Const, Ref] btVector3 scaling);
 };
 
 interface btTriangleMesh {


### PR DESCRIPTION
To efficiently generate a `btBvhTriangleMeshShape` with scaling, you need to construct a `btTriangleMesh` and call [this `setScaling` method](https://pybullet.org/Bullet/BulletFull/classbtStridingMeshInterface.html#a7963a24451e7c5c19f37da558993683a) on it prior to constructing the `btBvhTriangleMeshShape` -- if you instead call `setLocalScale` on the `btBvhTriangleMeshShape` after construction, it will have to rebuild the whole BVH.