### PR TITLE
Export getValue/setValue from Emscripten preamble

### DIFF
--- a/make.py
+++ b/make.py
@@ -58,7 +58,7 @@ def build():
   wasm = 'wasm' in sys.argv
   closure = 'closure' in sys.argv
 
-  args = '-O3 --llvm-lto 1 -s NO_EXIT_RUNTIME=1 -s NO_FILESYSTEM=1 -s EXPORTED_RUNTIME_METHODS=["Pointer_stringify"]'
+  args = '-O3 --llvm-lto 1 -s NO_EXIT_RUNTIME=1 -s NO_FILESYSTEM=1 -s EXPORTED_RUNTIME_METHODS=["Pointer_stringify","setValue","getValue"]'
   if not wasm:
     args += ' -s WASM=0 -s AGGRESSIVE_VARIABLE_ELIMINATION=1 -s ELIMINATE_DUPLICATE_FUNCTIONS=1 -s SINGLE_FILE=1 -s LEGACY_VM_SUPPORT=1'
   else:


### PR DESCRIPTION
These are small, and it seems like it's reasonable to expect a lot of high-performance physics code to want them. For example, using [`getValue`](https://emscripten.org/docs/api_reference/preamble.js.html#getValue) to read floats off a `btVector3` pointer directly would speed up [this debug drawer implementation](https://github.com/InfiniteLee/ammo-debug-drawer/blob/master/AmmoDebugDrawer.js#L105) by a lot, and using [`setValue`](https://emscripten.org/docs/api_reference/preamble.js.html#setValue) to write floats into the heap might be necessary to efficiently create large collision shapes.