### PR TITLE
getNumOverlappingPairCache

### DIFF
--- a/ammo.idl
+++ b/ammo.idl
@@ -462,6 +462,7 @@ interface btAxisSweep3 {
 };
 
 interface btBroadphaseInterface {
+  btOverlappingPairCache getOverlappingPairCache();
 };
 
 interface btCollisionConfiguration {

--- a/ammo.idl
+++ b/ammo.idl
@@ -458,7 +458,6 @@ interface btOverlappingPairCache {
 
 interface btAxisSweep3 {
   void btAxisSweep3([Ref] btVector3 worldAabbMin, [Ref] btVector3 worldAabbMax, optional long maxHandles, optional btOverlappingPairCache pairCache, optional boolean disableRaycastAccelerator);
-  btOverlappingPairCache getOverlappingPairCache();
 };
 
 interface btBroadphaseInterface {

--- a/ammo.idl
+++ b/ammo.idl
@@ -458,6 +458,7 @@ interface btOverlappingPairCache {
 
 interface btAxisSweep3 {
   void btAxisSweep3([Ref] btVector3 worldAabbMin, [Ref] btVector3 worldAabbMax, optional long maxHandles, optional btOverlappingPairCache pairCache, optional boolean disableRaycastAccelerator);
+  btOverlappingPairCache getOverlappingPairCache();
 };
 
 interface btBroadphaseInterface {

--- a/ammo.idl
+++ b/ammo.idl
@@ -128,6 +128,9 @@ interface btCollisionObject {
   boolean isKinematicObject();
   boolean isStaticObject();
   boolean isStaticOrKinematicObject();
+  [Const] float getRestitution();
+  [Const] float getFriction();
+  [Const] float getRollingFriction();
   void setRestitution(float rest);
   void setFriction(float frict);
   void setRollingFriction(float frict);
@@ -146,6 +149,9 @@ interface btCollisionObject {
 
 [NoDelete]
 interface btCollisionObjectWrapper {
+	[Const, Ref] btTransform getWorldTransform();
+	[Const] btCollisionObject getCollisionObject();
+	[Const] btCollisionShape getCollisionShape();
 };
 
 [Prefix="btCollisionWorld::"]

--- a/ammo.idl
+++ b/ammo.idl
@@ -502,8 +502,11 @@ interface btRigidBody {
   [Const, Ref] btTransform getCenterOfMassTransform();
   void setCenterOfMassTransform([Const, Ref] btTransform xform);
   void setSleepingThresholds(float linear, float angular);
+  [Const] float getLinearDamping();
+  [Const] float getAngularDamping();
   void setDamping(float lin_damping, float ang_damping);
   void setMassProps(float mass, [Const, Ref] btVector3 inertia);
+  [Const, Ref] btVector3 getLinearFactor();
   void setLinearFactor([Const, Ref] btVector3 linearFactor);
   void applyTorque([Const, Ref] btVector3 torque);
   void applyLocalTorque([Const, Ref] btVector3 torque);
@@ -520,6 +523,7 @@ interface btRigidBody {
   void setAngularVelocity([Const, Ref] btVector3 ang_vel);
   btMotionState getMotionState();
   void setMotionState(btMotionState motionState);
+  [Const, Ref] btVector3 getAngularFactor();
   void setAngularFactor([Const, Ref] btVector3 angularFactor);
   btRigidBody upcast(btCollisionObject colObj);
   void getAabb([Ref] btVector3 aabbMin, [Ref] btVector3 aabbMax);

--- a/ammo.idl
+++ b/ammo.idl
@@ -465,6 +465,7 @@ interface btOverlappingPairCallback {
 
 interface btOverlappingPairCache {
   void setInternalGhostPairCallback(btOverlappingPairCallback ghostPairCallback);
+  [Const] float getNumOverlappingPairs();
 };
 
 interface btAxisSweep3 {

--- a/ammo.idl
+++ b/ammo.idl
@@ -149,9 +149,9 @@ interface btCollisionObject {
 
 [NoDelete]
 interface btCollisionObjectWrapper {
-	[Const, Ref] btTransform getWorldTransform();
-	[Const] btCollisionObject getCollisionObject();
-	[Const] btCollisionShape getCollisionShape();
+  [Const, Ref] btTransform getWorldTransform();
+  [Const] btCollisionObject getCollisionObject();
+  [Const] btCollisionShape getCollisionShape();
 };
 
 [Prefix="btCollisionWorld::"]


### PR DESCRIPTION
Im surprised no one else is getting these missing ammo.idl entries.

No one **MUST NOT** have been using things like (not without all the recent ammo.idl changes): 

- Kinematic Character Controllers
- Ghost Object Collision Detection
- Global Contact Processing Callbacks
- Detail Rigidbody Configuration (Linear/Angular Factors And Damping)

And other advanced physics using Ammo.js out-the-box... But these ammo.idl changes ought to help with the next guy who comes along and want to get to the **Nitty Gritty** of using the buttlet API in JavaSciript eco-system using Ammo.js :)

