### PR TITLE
Update Ammo.idl

### DIFF
--- a/ammo.idl
+++ b/ammo.idl
@@ -145,6 +145,7 @@ interface btCollisionObject {
   void setUserIndex(long index);
   VoidPtr getUserPointer();
   void setUserPointer(VoidPtr userPointer);
+  [Const] btBroadphaseProxy getBroadphaseHandle();
 };
 
 [NoDelete]


### PR DESCRIPTION
Add btCollisionObject::getBroadphaseHandle() binding.

That should do her... That should all the main ways to get access to the **btBroadphaseProxy** needed for many of the lower level collision detection api