### PR TITLE
Add btEmptyShape to IDL

### DIFF
--- a/ammo.idl
+++ b/ammo.idl
@@ -209,7 +209,7 @@ interface btManifoldPoint {
   [Value] attribute btVector3 m_positionWorldOnB;
   [Value] attribute btVector3 m_positionWorldOnA;
   [Value] attribute btVector3 m_normalWorldOnB;
-  
+
   // Contact callback support
   attribute any m_userPersistentData;
 };
@@ -347,6 +347,16 @@ interface btConeShape {
 };
 btConeShape implements btCollisionShape;
 
+interface btConeShapeX {
+  void btConeShapeX(float radius, float height);
+};
+btConeShapeX implements btConeShape;
+
+interface btConeShapeZ {
+  void btConeShapeZ(float radius, float height);
+};
+btConeShapeZ implements btConeShape;
+
 interface btIntArray {
   long size();
   long at(long n);
@@ -390,16 +400,6 @@ interface btShapeHull {
   long numVertices();
   [Const] btVector3 getVertexPointer();
 };
-
-interface btConeShapeX {
-  void btConeShapeX(float radius, float height);
-};
-btConeShapeX implements btConeShape;
-
-interface btConeShapeZ {
-  void btConeShapeZ(float radius, float height);
-};
-btConeShapeZ implements btConeShape;
 
 interface btCompoundShape {
   void btCompoundShape(optional boolean enableDynamicAabbTree);
@@ -448,6 +448,11 @@ enum PHY_ScalarType {
 interface btConcaveShape {
 };
 btConcaveShape implements btCollisionShape;
+
+interface btEmptyShape {
+  void btEmptyShape();
+};
+btEmptyShape implements btConcaveShape;
 
 interface btStaticPlaneShape {
   void btStaticPlaneShape([Const, Ref] btVector3 planeNormal, float planeConstant);
@@ -667,7 +672,7 @@ interface btHingeConstraint {
   void setLimit(float low, float high, float softness, float biasFactor, optional float relaxationFactor);
   void enableAngularMotor(boolean enableMotor, float targetVelocity, float maxMotorImpulse);
   void setAngularOnly(boolean angularOnly);
-  
+
   void enableMotor(boolean enableMotor);
   void setMaxMotorImpulse(float maxMotorImpulse);
   //void setMotorTarget([Const,Ref] btQuaternion qAinB, float dt);
@@ -945,7 +950,7 @@ interface Node {
   [Value] attribute btVector3 m_v;
   [Value] attribute btVector3 m_f;
   [Value] attribute btVector3 m_n;
-  attribute float m_im;	
+  attribute float m_im;
   attribute float m_area;
 };
 
@@ -1024,7 +1029,7 @@ interface btSoftBody {
   [Value] attribute Config m_cfg;
   [Value] attribute tNodeArray m_nodes;
   [Value] attribute tMaterialArray m_materials;
-  [Value] attribute tAnchorArray m_anchors; 
+  [Value] attribute tAnchorArray m_anchors;
 
   [Const] boolean checkLink( long node0, long node1);
   [Const] boolean checkFace( long node0, long node1, long node2);


### PR DESCRIPTION
I needed the existing `btEmptyShape` so added it to the IDL. Perhaps someone will need it also one day.

Also moved the btConeShapeX and Z just below the btConeShape, just to keep things organized.
