### PR TITLE
feat: CMake Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ builds/glue.cpp
 builds/glue.js
 builds/glue.o
 builds/parser.out
+builds/t.js
 
 bullet/build
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
+builds/CMakeCache.txt
+builds/CMakeFiles/
+builds/Makefile
+builds/WebIDLGrammar.pkl
+builds/bullet/
+builds/cmake_install.cmake
+builds/glue.cpp
+builds/glue.js
+builds/glue.o
+builds/parser.out
+
 bullet/build
 node_modules
 *.diff

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 bullet/build
 node_modules
 *.diff
+
+# Vim
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,109 @@
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+set(CMAKE_TOOLCHAIN_FILE $ENV{EMSCRIPTEN}/cmake/Modules/Platform/Emscripten.cmake)
+set(WEBIDL_BINDER_SCRIPT $ENV{EMSCRIPTEN}/tools/webidl_binder.py)
+set(BUNDLE_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/bundle.py)
+set(WRAP_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/wrap.py)
+set(AMMO_HEADER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/ammo.h)
+set(AMMO_IDL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/ammo.idl)
+set(BULLET_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bullet/src/)
+
+set(BULLET_TARGETS BulletCollision BulletDynamics BulletSoftBody LinearMath)
+foreach(_TARGET ${BULLET_TARGETS})
+  list(APPEND BULLET_LIBS $<TARGET_FILE:${_TARGET}>)
+endforeach()
+
+# Default is 64*1024*1024 = 64MB
+set(TOTAL_MEMORY 67108864 CACHE STRING "Total Memory")
+
+# Enable for resizable heap, with some amount of slowness
+set(ALLOW_MEMORY_GROWTH 0 CACHE STRING "Allow Memory Growth")
+
+set(EMCC_ARGS
+  --js-transform "python ${BUNDLE_SCRIPT}"
+  --llvm-lto 1
+  -O3
+  -s ALLOW_MEMORY_GROWTH=${ALLOW_MEMORY_GROWTH}
+  -s EXPORTED_RUNTIME_METHODS=["UTF8ToString"]
+  -s EXPORT_NAME="Ammo"
+  -s MODULARIZE=1
+  -s NO_EXIT_RUNTIME=1
+  -s NO_FILESYSTEM=1
+  -s TOTAL_MEMORY=${TOTAL_MEMORY})
+
+if(${CLOSURE})
+  # Ignore closure errors about the bullet Node class
+  # (Node is a DOM thing too)
+  LIST(APPEND EMCC_ARGS
+    --closure 1
+    -s IGNORE_CLOSURE_COMPILER_ERRORS=1)
+else()
+  LIST(APPEND EMCC_ARGS
+    -s NO_DYNAMIC_EXECUTION=1)
+endif()
+
+if(${ADD_FUNCTION_SUPPORT})
+  LIST(APPEND EMCC_ARGS
+    -s RESERVED_FUNCTION_POINTERS=20
+    -s EXTRA_EXPORTED_RUNTIME_METHODS=["addFunction"])
+endif()
+
+set(EMCC_JS_ARGS ${EMCC_ARGS}
+  -s AGGRESSIVE_VARIABLE_ELIMINATION=1
+  -s ELIMINATE_DUPLICATE_FUNCTIONS=1
+  -s LEGACY_VM_SUPPORT=1
+  -s SINGLE_FILE=1
+  -s WASM=0)
+
+set(EMCC_WASM_ARGS ${EMCC_ARGS}
+  -s BINARYEN_IGNORE_IMPLICIT_TRAPS=1
+  -s WASM=1)
+
+set(EMCC_GLUE_ARGS
+  -c
+  -I${BULLET_SRC_DIR}
+  -include${AMMO_HEADER_FILE})
+
+
+#######################################
+project("ammo")
+add_subdirectory(bullet EXCLUDE_FROM_ALL)
+
+
+#######################################
+add_custom_command(
+  OUTPUT glue.cpp
+  BYPRODUCTS glue.js parser.out WebIDLGrammar.pkl
+  COMMAND python ${WEBIDL_BINDER_SCRIPT} ${AMMO_IDL_FILE} glue
+  DEPENDS ${AMMO_IDL_FILE}
+  COMMENT "Generating ammo bindings"
+  VERBATIM)
+add_custom_command(
+  OUTPUT glue.o
+  COMMAND emcc glue.cpp ${EMCC_GLUE_ARGS} -o glue.o
+  DEPENDS glue.cpp ${AMMO_HEADER_FILE}
+  COMMENT "Building ammo bindings"
+  VERBATIM)
+add_custom_target(ammo-bindings ALL DEPENDS glue.o)
+
+
+#######################################
+add_custom_command(
+  OUTPUT ammo.js
+  COMMAND emcc glue.o ${BULLET_LIBS} ${EMCC_JS_ARGS} -o ammo.js
+  COMMAND python ${WRAP_SCRIPT} ammo.js
+  DEPENDS ammo-bindings ${BULLET_TARGETS}
+  COMMENT "Building ammo javascript"
+  VERBATIM)
+add_custom_target(ammo-javascript ALL DEPENDS ammo.js)
+
+
+#######################################
+add_custom_command(
+  OUTPUT ammo.wasm.js ammo.wasm.wasm
+  COMMAND emcc glue.o ${BULLET_LIBS} ${EMCC_WASM_ARGS} -o ammo.wasm.js
+  COMMAND python ${WRAP_SCRIPT} ammo.wasm.js
+  DEPENDS ammo-bindings ${BULLET_TARGETS}
+  COMMENT "Building ammo webassembly"
+  VERBATIM)
+add_custom_target(ammo-wasm ALL DEPENDS ammo.wasm.js ammo.wasm.wasm)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ foreach(_TARGET ${BULLET_TARGETS})
   list(APPEND BULLET_LIBS $<TARGET_FILE:${_TARGET}>)
 endforeach()
 
+# Disable bullet graphical benchmarks
+set(USE_GRAPHICAL_BENCHMARK OFF)
+
 # Default is 64*1024*1024 = 64MB
 set(TOTAL_MEMORY 67108864 CACHE STRING "Total Memory")
 

--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,7 @@
 # Enable add function support with ADD_FUNCTION_SUPPORT=1
 #
 INCLUDES := \
-	bullet/src/btBulletDynamicsCommon.h \
-	bullet/src/BulletCollision/CollisionDispatch/btGhostObject.h \
-	bullet/src/BulletCollision/CollisionShapes/btConvexPolyhedron.h \
-	bullet/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.h \
-	bullet/src/BulletCollision/CollisionShapes/btShapeHull.h \
-	bullet/src/BulletDynamics/Character/btKinematicCharacterController.h \
-	bullet/src/BulletSoftBody/btDefaultSoftBodySolver.h \
-	bullet/src/BulletSoftBody/btSoftBody.h \
-	bullet/src/BulletSoftBody/btSoftBodyHelpers.h \
-	bullet/src/BulletSoftBody/btSoftBodyRigidBodyCollisionConfiguration.h \
-	bullet/src/BulletSoftBody/btSoftRigidDynamicsWorld.h \
-	idl_templates.h
+	ammo.h
 
 BULLET_LIBS := \
 	bullet/build/src/.libs/libBulletCollision.a \

--- a/ammo.h
+++ b/ammo.h
@@ -1,0 +1,20 @@
+#include "btBulletDynamicsCommon.h"
+#include "BulletCollision/CollisionDispatch/btGhostObject.h"
+#include "BulletCollision/CollisionShapes/btConvexPolyhedron.h"
+#include "BulletCollision/CollisionShapes/btHeightfieldTerrainShape.h"
+#include "BulletCollision/CollisionShapes/btShapeHull.h"
+#include "BulletDynamics/Character/btKinematicCharacterController.h"
+#include "BulletSoftBody/btDefaultSoftBodySolver.h"
+#include "BulletSoftBody/btSoftBody.h"
+#include "BulletSoftBody/btSoftBodyHelpers.h"
+#include "BulletSoftBody/btSoftBodyRigidBodyCollisionConfiguration.h"
+#include "BulletSoftBody/btSoftRigidDynamicsWorld.h"
+
+//Web IDL doesn't seem to support C++ templates so this is the best we can do
+//https://stackoverflow.com/questions/42517010/is-there-a-way-to-create-webidl-bindings-for-c-templated-types#comment82966925_42517010
+typedef btAlignedObjectArray<btVector3> btVector3Array;
+typedef btAlignedObjectArray<btFace> btFaceArray;
+typedef btAlignedObjectArray<int> btIntArray;
+typedef btAlignedObjectArray<btIndexedMesh> btIndexedMeshArray;
+typedef btAlignedObjectArray<const btCollisionObject*> btConstCollisionObjectArray;
+typedef btAlignedObjectArray<btScalar> btScalarArray;

--- a/bullet/CMakeLists.txt
+++ b/bullet/CMakeLists.txt
@@ -429,11 +429,13 @@ list (APPEND BULLET_LIBRARIES BulletCollisions)
 list (APPEND BULLET_LIBRARIES BulletDynamics)
 list (APPEND BULLET_LIBRARIES BulletSoftBody)
 set (BULLET_USE_FILE ${CMAKE_INSTALL_PREFIX}/${BULLET_CONFIG_CMAKE_PATH}/UseBullet.cmake)
-configure_file ( ${CMAKE_SOURCE_DIR}/BulletConfig.cmake.in
+# XXX AMMO Changed CMAKE_SOURCE_DIR to CMAKE_CURRENT_SOURCE_DIR
+configure_file ( ${CMAKE_CURRENT_SOURCE_DIR}/BulletConfig.cmake.in
                  ${CMAKE_CURRENT_BINARY_DIR}/BulletConfig.cmake
                  @ONLY ESCAPE_QUOTES
                )
-install ( FILES ${CMAKE_SOURCE_DIR}/UseBullet.cmake
+# XXX AMMO Changed CMAKE_SOURCE_DIR to CMAKE_CURRENT_SOURCE_DIR
+install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/UseBullet.cmake
                 ${CMAKE_CURRENT_BINARY_DIR}/BulletConfig.cmake
           DESTINATION ${BULLET_CONFIG_CMAKE_PATH}
         )

--- a/idl_templates.h
+++ b/idl_templates.h
@@ -1,8 +1,0 @@
-//Web IDL doesn't seem to support C++ templates so this is the best we can do
-//https://stackoverflow.com/questions/42517010/is-there-a-way-to-create-webidl-bindings-for-c-templated-types#comment82966925_42517010
-typedef btAlignedObjectArray<btVector3> btVector3Array;
-typedef btAlignedObjectArray<btFace> btFaceArray;
-typedef btAlignedObjectArray<int> btIntArray;
-typedef btAlignedObjectArray<btIndexedMesh> btIndexedMeshArray;
-typedef btAlignedObjectArray<const btCollisionObject*> btConstCollisionObjectArray;
-typedef btAlignedObjectArray<btScalar> btScalarArray;

--- a/make.py
+++ b/make.py
@@ -5,20 +5,7 @@ from subprocess import Popen, PIPE, STDOUT
 
 # Definitions
 
-INCLUDES = ['btBulletDynamicsCommon.h',
-os.path.join('BulletCollision', 'CollisionShapes', 'btHeightfieldTerrainShape.h'),
-os.path.join('BulletCollision', 'CollisionShapes', 'btConvexPolyhedron.h'),
-os.path.join('BulletCollision', 'CollisionShapes', 'btShapeHull.h'),
-os.path.join('BulletCollision', 'CollisionDispatch', 'btGhostObject.h'),
-
-os.path.join('BulletDynamics', 'Character', 'btKinematicCharacterController.h'),
-
-os.path.join('BulletSoftBody', 'btSoftBody.h'),
-os.path.join('BulletSoftBody', 'btSoftRigidDynamicsWorld.h'), os.path.join('BulletSoftBody', 'btDefaultSoftBodySolver.h'),
-os.path.join('BulletSoftBody', 'btSoftBodyRigidBodyCollisionConfiguration.h'),
-os.path.join('BulletSoftBody', 'btSoftBodyHelpers.h'),
-
-os.path.join('..', '..', 'idl_templates.h')]
+INCLUDES = [ os.path.join('..', '..', 'ammo.h') ]
 
 # Startup
 


### PR DESCRIPTION
Adds support for cmake builds. This simplifies interaction with bullet quite a bit, you can build javascript and wasm flavors of ammo with closure post processing like this:

```bash
$ cd builds
$ cmake .. -DCLOSURE=1
$ make
```

`-DTOTAL_MEMORY`, `-DALLOW_MEMORY_GROWTH`, `-DADD_FUNCTION_SUPPORT` can be passed to cmake as well.