### PR TITLE
fix: Can't build native bullet with clang >= 8

### DIFF
--- a/bullet/src/LinearMath/btVector3.h
+++ b/bullet/src/LinearMath/btVector3.h
@@ -39,7 +39,8 @@ subject to the following restrictions:
 #endif
 
 
-#define BT_SHUFFLE(x,y,z,w) ((w)<<6 | (z)<<4 | (y)<<2 | (x))
+// XXX AMMO clang 8 fix cherry-picked from https://github.com/bulletphysics/bullet3/pull/2232
+#define BT_SHUFFLE(x, y, z, w) (((w) << 6 | (z) << 4 | (y) << 2 | (x)) & 0xff)
 //#define bt_pshufd_ps( _a, _mask ) (__m128) _mm_shuffle_epi32((__m128i)(_a), (_mask) )
 #define bt_pshufd_ps( _a, _mask ) _mm_shuffle_ps((_a), (_a), (_mask) )
 #define bt_splat3_ps( _a, _i ) bt_pshufd_ps((_a), BT_SHUFFLE(_i,_i,_i, 3) )


### PR DESCRIPTION
Patches bullet btVector3 BT_SHUFFLE for clang >= 8
Cherry-picked from  https://github.com/bulletphysics/bullet3/pull/2232/files