### PR TITLE
Remove callback function notation from idl

### DIFF
--- a/ammo.idl
+++ b/ammo.idl
@@ -737,13 +737,11 @@ interface btContactSolverInfo {
   attribute long m_numIterations;
 };
 
-callback btInternalTickCallback = void (btDynamicsWorld world, float timeStep);
-
 interface btDynamicsWorld {
   void addAction(btActionInterface action);
   void removeAction(btActionInterface action);
   [Ref] btContactSolverInfo getSolverInfo();
-  void setInternalTickCallback(btInternalTickCallback cb, optional VoidPtr worldUserInfo, optional boolean isPreTick);
+  void setInternalTickCallback(VoidPtr cb, optional VoidPtr worldUserInfo, optional boolean isPreTick);
 };
 btDynamicsWorld implements btCollisionWorld;
 


### PR DESCRIPTION
See #327

I think notation is just not supported in emscripten's WebIDL binder. Let's see if CI passes without it.