### PR TITLE
Add collision object to convex shape cast result

### DIFF
--- a/ammo.idl
+++ b/ammo.idl
@@ -253,7 +253,7 @@ interface ConvexResultCallback {
 [Prefix="btCollisionWorld::"]
 interface ClosestConvexResultCallback {
   void ClosestConvexResultCallback([Const, Ref] btVector3 convexFromWorld, [Const, Ref] btVector3 convexToWorld);
-
+  [Const] attribute btCollisionObject m_hitCollisionObject;
   [Value] attribute btVector3 m_convexFromWorld;
   [Value] attribute btVector3 m_convexToWorld;
   [Value] attribute btVector3 m_hitNormalWorld;


### PR DESCRIPTION
The change adds the collision object to the convex shape sweep test result.