### PR TITLE
Fix CI workflow deprecation errors

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '^3.5'
-      - uses: mymindstorm/setup-emsdk@v7
+      - uses: mymindstorm/setup-emsdk@v8
         with:
           version: 'latest'
       - run: emcc -v

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -4,7 +4,6 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     steps:
-      - run: cmake --version
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '^3.5'
-      - uses: mymindstorm/setup-emsdk@v6
+      - uses: mymindstorm/setup-emsdk@v7
         with:
           version: 'latest'
       - run: emcc -v

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -4,6 +4,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     steps:
+      - run: cmake --version
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
Fixes build errors from deprecated `add-path` and `set-env` surfacing in #352

More info at https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/