### PR TITLE
Fix docker build

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -156,6 +156,19 @@ On windows, you can build using cmake's
 Note that if you have not installed emscripten via the emsdk, you can configure
 its location with `-DEMSCRIPTEN_ROOT`.
 
+### Building using Docker
+
+ammo.js can also be built with [Docker](https://www.docker.com).
+This offers many advantages (keeping its native environment clean, portability, etc.).
+To do this, you just have to install Docker and run:
+
+  ```bash
+  $ docker-compose build  # to create the Docker image
+  $ docker-compose up     # to create the Docker container and build ammo.js
+  ```
+
+If you want to add arguments to cmake, you have to edit the `docker-compose.yml` file. 
+
 Reducing Build Size
 -------------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,4 @@ services:
     build: .
     volumes:
       - .:/code
-    command: sh build.sh 
+    command: bash -c "rm builds/ammo.* && cmake -B builds && cmake --build builds"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,4 @@ services:
     build: .
     volumes:
       - .:/code
-    command: bash -c "rm builds/ammo.* && cmake -B builds && cmake --build builds"
+    command: bash -c "rm -f builds/ammo.* && cmake -B builds && cmake --build builds"


### PR DESCRIPTION
The Docker build system introduced in #265 is currently broken (it relies on `build.sh` which has been dropped) and not documented while very useful in my point of view (among others, to build `ammojs` from macOS).

This PR fixes this:

- [x] Fix docker-compose.yml in order to use directly `cmake` as documented in the `building` section.
- [x] Add some relative documentation.
