### PR TITLE
Expose m_flags in RayResultCallback

### DIFF
--- a/ammo.idl
+++ b/ammo.idl
@@ -163,6 +163,7 @@ interface RayResultCallback {
   attribute short m_collisionFilterMask;
   attribute float m_closestHitFraction;
   [Const] attribute btCollisionObject m_collisionObject;
+  attribute unsigned long m_flags;
 };
 
 [Prefix="btCollisionWorld::"]


### PR DESCRIPTION
When a raytest is performed, it may return the backface hit result:

```
var rayCallback = new Ammo.AllHitsRayResultCallback(start, end);
dynamicsWorld.rayTest(start, end, rayCallback);
```
Exposing the flag on the callback allows us to set it so that the backfaces are ignored:
```
var rayCallback = new Ammo.AllHitsRayResultCallback(start, end);
rayCallback.set_m_flags(1 << 0);
dynamicsWorld.rayTest(start, end, rayCallback);
```