### PR TITLE
added support for JSImplementation of btMotionState

### DIFF
--- a/ammo.idl
+++ b/ammo.idl
@@ -109,6 +109,13 @@ interface btMotionState {
   void setWorldTransform([Ref] btTransform worldTrans);
 };
 
+[JSImplementation="btMotionState"]
+interface MotionState {
+  void MotionState();
+  [Const] void getWorldTransform([Ref] btTransform worldTrans);
+  void setWorldTransform([Const, Ref] btTransform worldTrans);
+};
+
 interface btDefaultMotionState {
   void btDefaultMotionState([Ref] optional btTransform startTrans, [Ref] optional btTransform centerOfMassOffset);
   [Value] attribute btTransform m_graphicsWorldTrans;


### PR DESCRIPTION
The btMotionState is meant to be used in a callback like fashion for performance reasons and I found that there was really no way to use it that way without this additional binding.


How to use:
```js
const motionState = new Ammo.MotionState();
motionState.getWorldTransform = (transformRef) => {
    const btTransform = Ammo.wrapPointer(transformRef, Ammo.btTransform);
    // update the transform from your render state
    // i.e. btTransform.setOrigin(), btTransform.setRotation()
}
motionState.setWorldTransform = (transformRef) => {
    const btTransform = Ammo.wrapPointer(transformRef, Ammo.btTransform);
    // update your render state from the transform
    // i.e. btTransform.getOrigin(), btTransform.getRotation()
}

const rigidBodyInfo = new Ammo.btRigidBodyConstructionInfo(mass, motionState, ammoShape, localInertia);
```