### PR TITLE
Reverse back wheels in webgl_demo_vehicle

### DIFF
--- a/examples/webgl_demo_vehicle/index.html
+++ b/examples/webgl_demo_vehicle/index.html
@@ -335,8 +335,8 @@
 
 				addWheel(true, new Ammo.btVector3(wheelHalfTrackFront, wheelAxisHeightFront, wheelAxisFrontPosition), wheelRadiusFront, wheelWidthFront, FRONT_LEFT);
 				addWheel(true, new Ammo.btVector3(-wheelHalfTrackFront, wheelAxisHeightFront, wheelAxisFrontPosition), wheelRadiusFront, wheelWidthFront, FRONT_RIGHT);
-				addWheel(false, new Ammo.btVector3(-wheelHalfTrackBack, wheelAxisHeightBack, wheelAxisPositionBack), wheelRadiusBack, wheelWidthBack, BACK_LEFT);
-				addWheel(false, new Ammo.btVector3(wheelHalfTrackBack, wheelAxisHeightBack, wheelAxisPositionBack), wheelRadiusBack, wheelWidthBack, BACK_RIGHT);
+				addWheel(false, new Ammo.btVector3(wheelHalfTrackBack, wheelAxisHeightBack, wheelAxisPositionBack), wheelRadiusBack, wheelWidthBack, BACK_LEFT);
+				addWheel(false, new Ammo.btVector3(-wheelHalfTrackBack, wheelAxisHeightBack, wheelAxisPositionBack), wheelRadiusBack, wheelWidthBack, BACK_RIGHT);
 
 				// Sync keybord actions and physics and graphics
 				function sync(dt) {

--- a/examples/webgl_demo_vehicle/index.html
+++ b/examples/webgl_demo_vehicle/index.html
@@ -65,7 +65,6 @@
 			// Graphics variables
 			var container, stats, speedometer;
 			var camera, controls, scene, renderer;
-			var terrainMesh, texture;
 			var clock = new THREE.Clock();
 			var materialDynamic, materialStatic, materialInteractive;
 
@@ -78,9 +77,6 @@
 
 			var syncList = [];
 			var time = 0;
-			var objectTimePeriod = 3;
-			var timeNextSpawn = time + objectTimePeriod;
-			var maxNumObjects = 30;
 
 			// Keybord actions
 			var actions = {};


### PR DESCRIPTION
While using the webgl_demo_vehicle example with the car model and wheels from https://github.com/pmndrs/racing-game/tree/main/public/models I found out that the back wheels were actually reversed. The front wheels are fine.
Although it doesn't show in the demo that they are reversed and it doesn't seem to impact the physics, I thought I would still create the PR to fix it.