### PR TITLE
Repair the continuous CI workflow

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -4,29 +4,31 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '^3.5'
-      - uses: mymindstorm/setup-emsdk@v8
+          python-version: '3.x'
+      - uses: actions/setup-node@v4
         with:
-          version: 'latest'
+          node-version: 18
+      - uses: mymindstorm/setup-emsdk@v16
+        with:
+          version: "3.1.35"
       - run: emcc -v
-      - run: python -V
       - run: cmake --version
-      - run: ${{ matrix.make || 'make' }} --version
-      - run: cmake -B builds -DCLOSURE=1 ${{ matrix.cmake-args }}
+      - run: cmake -B builds -DCLOSURE=1 "-DCMAKE_POLICY_VERSION_MINIMUM=3.5" ${{ matrix.cmake-args }}
       - run: cmake --build builds -- VERBOSE=1
       - run: npm ci
       - name: Test Ammo Javascript
         run: npx ava
         env:
-          AMMO_BUILD: builds/ammo.js
+          AMMO_PATH: builds/ammo.js
       - name: Test Ammo WebAssembly
         run: npx ava
         env:
-          AMMO_BUILD: builds/ammo.wasm.js
+          AMMO_PATH: builds/ammo.wasm.js
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest
@@ -35,4 +37,3 @@ jobs:
         include:
           - os: windows-latest
             cmake-args: -G 'MinGW Makefiles'
-            make: mingw32-make

--- a/tests/helpers/load-ammo.js
+++ b/tests/helpers/load-ammo.js
@@ -1,8 +1,9 @@
 const { resolve } = require('path');
 
 async function loadAmmo(options) {
-  const { AMMO_PATH, PWD } = process.env;
-  const path = AMMO_PATH ? resolve(PWD, AMMO_PATH) : '../../builds/ammo.js';
+  const { AMMO_PATH } = process.env;
+  // Resolve against cwd (always defined) rather than $PWD, which is unset on Windows.
+  const path = AMMO_PATH ? resolve(AMMO_PATH) : '../../builds/ammo.js';
   const Ammo = require(path);
   return Ammo(options);
 }


### PR DESCRIPTION
CI currently fails on **every** PR at the `mymindstorm/setup-emsdk@v8` step — `emsdk install latest` errors with `No tool or SDK found by name 'sdk-releases-upstream-…-64bit'`, before the build even runs. This repairs the workflow and gets it green on all three runners again:

- **Pin emsdk to 3.1.35** via `setup-emsdk@v16` — pinning avoids the `latest`-tag rot, and 3.1.35 matches the toolchain the committed `builds/*` were produced with.
- **Modernize actions** — `checkout@v4`, `setup-python@v5` (the `@v2` versions are Node-16 EOL).
- **Pin Node 18** via `setup-node@v4` — the `add-function` contact-callback test regressed on Node 20+; it passes on 18.
- **`-DCMAKE_POLICY_VERSION_MINIMUM=3.5`** — CMake 4.x (now on the macOS/Windows runners) rejects vendored Bullet's pre-3.5 `cmake_minimum_required`. Quoted so PowerShell doesn't split `3.5` into `3` + `.5` on Windows.
- **Resolve `AMMO_PATH` via cwd** in `tests/helpers/load-ammo.js` — `$PWD` is unset on Windows, so the `AMMO_PATH` branch threw there. This also makes the *Test Ammo WebAssembly* step actually load the wasm build (previously `AMMO_BUILD` was set, which the helper ignores).

Validated green across ubuntu/macOS/Windows on my fork: https://github.com/willeastcott/ammo.js/actions/runs/27560212672

Independent of #446, but unblocks its CI.
